### PR TITLE
Fix UnicodeError when using non-english locales

### DIFF
--- a/plex_mpv_shim/client.py
+++ b/plex_mpv_shim/client.py
@@ -28,6 +28,8 @@ from .media import Media
 from .player import playerManager
 from .subscribers import remoteSubscriberManager, RemoteSubscriber
 from .timeline import timelineManager
+import locale
+locale.setlocale(locale.LC_TIME, 'en_GB.utf8')
 
 log = logging.getLogger("client")
 


### PR DESCRIPTION
When using non-english locales, the date header might contain characters not included in the Latin-1 character set, this PR fixes this.