### PR TITLE
Use certifi for urllib.request.urlopen calls

### DIFF
--- a/plex_mpv_shim/client.py
+++ b/plex_mpv_shim/client.py
@@ -1,3 +1,4 @@
+import certifi
 import datetime
 import json
 import logging

--- a/plex_mpv_shim/media.py
+++ b/plex_mpv_shim/media.py
@@ -3,6 +3,7 @@ from enum import Enum
 import logging
 import urllib.request, urllib.parse, urllib.error
 import urllib.parse
+import certifi
 import requests
 import uuid
 
@@ -256,7 +257,7 @@ class Video(MediaItem):
         return audio_formats, protocols
 
     def get_decision(self, url, args):
-        tree = et.parse(urllib.request.urlopen(get_plex_url(urllib.parse.urljoin(self.parent.server_url, url), args)))
+        tree = et.parse(urllib.request.urlopen(get_plex_url(urllib.parse.urljoin(self.parent.server_url, url), args), cafile=certifi.where()))
         treeRoot = tree.getroot()
         decisionText = treeRoot.get("generalDecisionText") or treeRoot.get("mdeDecisionText")
         decision = treeRoot.get("generalDecisionCode") or treeRoot.get("mdeDecisionCode")
@@ -533,7 +534,7 @@ class XMLCollection(object):
         """
         self.path       = urllib.parse.urlparse(url)
         self.server_url = self.path.scheme + "://" + self.path.netloc
-        self.tree       = et.parse(urllib.request.urlopen(get_plex_url(url)))
+        self.tree       = et.parse(urllib.request.urlopen(get_plex_url(url), cafile=certifi.where()))
 
     def get_path(self, path):
         parsed_url = urllib.parse.urlparse(path)
@@ -691,7 +692,7 @@ class Media(XMLCollection):
 
     def get_machine_identifier(self):
         if not hasattr(self, "_machine_identifier"):
-            doc = urllib.request.urlopen(get_plex_url(self.server_url))
+            doc = urllib.request.urlopen(get_plex_url(self.server_url), cafile=certifi.where())
             tree = et.parse(doc)
             setattr(self, "_machine_identifier", tree.find('.').get("machineIdentifier"))
         return getattr(self, "_machine_identifier", None)

--- a/plex_mpv_shim/utils.py
+++ b/plex_mpv_shim/utils.py
@@ -1,3 +1,4 @@
+import certifi
 import logging
 import os
 import urllib.request, urllib.parse, urllib.error
@@ -126,7 +127,7 @@ def safe_urlopen(url, data=None, quiet=False):
     url = get_plex_url(url, data, quiet)
 
     try:
-        page = urllib.request.urlopen(url)
+        page = urllib.request.urlopen(url, cafile=certifi.where())
         if page.code == 200:
             return True
         log.error("Error opening URL '%s': page returned %d" % (sanitize_msg(url),


### PR DESCRIPTION
This should fix issues with Windows users and letsencrypt CA expirations.

Ideally this would be replaced with usage of requests everywhere which already uses certifi under the hood.

Fix #52 