### PR TITLE
Add credits detection functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ Currently on Windows the built-in MPV does not work with SVP. You must download 
  - `stop_idle` - Stop the player when idle. (Requires `idle_when_paused`.) Default: `false`
  - `skip_intro_always` - Always skip intros, without asking. Default: `false`
  - `skip_intro_prompt` - Prompt to skip intro via seeking. Default: `true`
+ - `skip_credits_always` - Always skip credits, without asking. Default: `false`
+ - `skip_credits_prompt` - Prompt to skip credits via seeking. Default: `true`
  - `menu_mouse` - Enable mouse support in the menu. Default: `true`
      - This requires MPV to be compiled with lua support.
 

--- a/plex_mpv_shim/conf.py
+++ b/plex_mpv_shim/conf.py
@@ -70,6 +70,8 @@ class Settings(object):
         "seek_left":            -5,
         "skip_intro_always":    False,
         "skip_intro_prompt":    True,
+        "skip_credits_always":  False,
+        "skip_credits_prompt":  True,
         "shader_pack_enable":   True,
         "shader_pack_custom":   False,
         "shader_pack_remember": True,

--- a/plex_mpv_shim/media.py
+++ b/plex_mpv_shim/media.py
@@ -90,6 +90,8 @@ class Video(MediaItem):
         self.trs_ovr       = None
         self.intro_start   = None
         self.intro_end     = None
+        self.credits_start = None
+        self.credits_end   = None
 
         if media:
             self.select_media(media, part)
@@ -105,6 +107,16 @@ class Video(MediaItem):
                 log.info("Intro Detected: {0} - {1}".format(self.intro_start, self.intro_end))
         except:
             log.error("Could not detect intro.", exc_info=True)
+
+        # TODO de-duplicate this code in some way - it's ugly
+        try:
+            marker = self.node.find("./Marker[@type='credits']")
+            if marker is not None:
+                self.credits_start = float(marker.get('startTimeOffset')) / 1e3
+                self.credits_end = float(marker.get('endTimeOffset')) / 1e3
+                log.info("Credits Detected: {0} - {1}".format(self.credits_start, self.credits_end))
+        except:
+            log.error("Could not detect credits.", exc_info=True)
 
         self.map_streams()
 


### PR DESCRIPTION
Suggested in #86

Tried to avoid duplicate code where ever possible, but I didn't get too clever because I wanted to just get the functionality working

Some notes:
* Factored the intro checking logic in `PlayerManager.update` to `PlayerManager.check_intro_or_credits` just for visual clarity
* Similarly factored some common logic into new `PlayerManager.skip_marker` function to implement `PlayerManager.skip_credits`
* Added credits skip functionality wherever intro skip existed (seeking, media keys, etc)
* Added two new options for credit skip prompt and always skip credits + added those options to the readme