### PR TITLE
Rename python-mpv dependency to match upstream

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.6',
-    install_requires=['python-mpv', 'requests', 'python-mpv-jsonipc>=1.1.8', 'certifi'],
+    install_requires=['mpv', 'requests', 'python-mpv-jsonipc>=1.1.8', 'certifi'],
     include_package_data=True
 
 )


### PR DESCRIPTION
`python-mpv` was renamed upstream to just `mpv` in [this commit](https://github.com/jaseg/python-mpv/commit/d34b6252f7c3a02e9bcde8f690c0c8e941ef898d) -- update setup.py to reflect the new name.