### PR TITLE
fix: reduce startup delay

### DIFF
--- a/plex_mpv_shim/timeline.py
+++ b/plex_mpv_shim/timeline.py
@@ -132,7 +132,14 @@ class TimelineManager(threading.Thread):
             return False
 
     def WaitForTimeline(self, subscriber):
-        subscriber.get_poll_evt().wait(30)
+        # Use a shorter timeout when player is stopped to reduce startup/resume delays
+        # but not so short that it causes rapid polling
+        if subscriber.commandID == 0 or playerManager.get_state() == "stopped":
+            timeout = 3  # 3 seconds for initial connection or when stopped
+        else:
+            timeout = 30  # Normal 30-second long polling during playback
+
+        subscriber.get_poll_evt().wait(timeout)
         return self.GetCurrentTimeLinesXML(subscriber)
 
     def GetCurrentTimeLinesXML(self, subscriber, tlines=None):


### PR DESCRIPTION
The timeline polling was using a fixed 30-second timeout for all requests, causing a 20-30 second delay when selecting plex-mpv-shim as a player in the Plex web UI. This fix uses a 3-second timeout for initial connections and when the player is stopped, while maintaining the 30-second timeout during active playback for efficient long-polling.