### PR TITLE
add app_log_level configuration option

### DIFF
--- a/plex_mpv_shim/conf.py
+++ b/plex_mpv_shim/conf.py
@@ -48,6 +48,7 @@ class Settings(object):
         "enable_osc":           True,
         "log_decisions":        False,
         "mpv_log_level":        "info",
+        "app_log_level":        "info",
         "idle_when_paused":     False,
         "stop_idle":            False,
         "kb_stop":              "q",

--- a/plex_mpv_shim/mpv_shim.py
+++ b/plex_mpv_shim/mpv_shim.py
@@ -30,6 +30,16 @@ def main():
     settings.load(conf_file)
     settings.add_listener(update_gdm_settings)
     
+    log_level_mapping = {
+        "debug": logging.DEBUG,
+        "info": logging.INFO,
+        "warning": logging.WARNING,
+        "error": logging.ERROR,
+        "critical": logging.CRITICAL
+    }
+    app_log_level = log_level_mapping.get(settings.app_log_level.lower(), logging.INFO)
+    logging.getLogger().setLevel(app_log_level)
+    
     if sys.platform.startswith("darwin"):
         multiprocessing.set_start_method('forkserver')
 


### PR DESCRIPTION
Add a new configuration option to control the application's logging verbosity separately from MPV's internal logging. This allows users to reduce debug message spam by setting app_log_level to "info" or higher while keeping MPV logging independent.

The default level is "info" to provide a better out-of-box experience.